### PR TITLE
vorpal-setorprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Vorpal supports community extensions, which add to the functionality of Vorpal p
 - [tour](https://github.com/vorpaljs/vorpal-tour) - Build an interactive tour for your Vorpal app.
 - [hacker-news](https://github.com/vorpaljs/vorpal-hacker-news) - Pulls the top trending items from Hacker News.
 
+##### Category Name
+- [setorprint](https://github.com/AljoschaMeyer/vorpal-setorprint) - Quickly generate commands which either set or print a parameter.
+
 ### Vantage-only extensions
 
 [Vantage.js](https://github.com/dthree/vantage) extends Vorpal, giving it client / server functionality. While Vantage supports all Vorpal extensions, the following extensions are only applicable to Vantage.

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ Vorpal supports community extensions, which add to the functionality of Vorpal p
 ##### Realtime
 
 - [use](https://github.com/vorpaljs/vorpal-use) - Import Vorpal extensions live: while your app is running.
-- [watch](https://github.com/vorpaljs/vorpal-watch) - Updates your live Vorpal extensions in realtime.
 
 ##### Misc
 
 - [tour](https://github.com/vorpaljs/vorpal-tour) - Build an interactive tour for your Vorpal app.
 - [hacker-news](https://github.com/vorpaljs/vorpal-hacker-news) - Pulls the top trending items from Hacker News.
 
-##### Category Name
-- [setorprint](https://github.com/AljoschaMeyer/vorpal-setorprint) - Quickly generate commands which either set or print a parameter.
+##### Vorpal development tools
+- [watch](https://github.com/vorpaljs/vorpal-watch) - Updates your live Vorpal extensions in realtime.
+- [setorprint](https://github.com/AljoschaMeyer/vorpal-setorprint) - Quickly generate commands which either set or print a parameter. Think instant getters/setters for the console.
 
 ### Vantage-only extensions
 


### PR DESCRIPTION
[setorprint](https://github.com/AljoschaMeyer/vorpal-setorprint) - because I am that lazy, and other might be too. Or, I mean, because code reusage is a good thing. Yes, that was the reason.

My nonnativespeakerness allows me to construct words by chaining them, but prevents me from finding a good title for the category. While the other extensions on the list directly add functionality to a program, this one is more of a utility for the coder. [log](https://github.com/AljoschaMeyer/vorpal-log) would go into the same category, once it works with vantage. Or at least into the same set of categories - are those nestable?  
Anyways, I hope you have a good name for this category - even if this extension doesn't qualify as 'awesome', the logging thing will need the category.
