### PR TITLE
Remove vorpal-only restriction for vorpal-log

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Vorpal supports community extensions, which add to the functionality of Vorpal p
 ##### Vorpal development tools
 - [watch](https://github.com/vorpaljs/vorpal-watch) - Updates your live Vorpal extensions in realtime.
 - [setorprint](https://github.com/AljoschaMeyer/vorpal-setorprint) - Quickly generate commands which either set or print a parameter. Think instant getters/setters for the console.
-- [log](https://github.com/AljoschaMeyer/vorpal-log) - Logging utility for Vorpal - comes with logging levels, formatters, and is extensible. Currently not working with vantage.
+- [log](https://github.com/AljoschaMeyer/vorpal-log) - Logging utility for Vorpal - comes with logging levels, formatters, and is extensible.
 
 ### Vantage-only extensions
 


### PR DESCRIPTION
vorpal-log now uses vorpal.activeCommand and works with things like vantage, piping etc.
