### PR TITLE
Add lifxsh under "Projects"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [birdknife](https://github.com/vanita5/birdknife) - A full featured [Twitter](https://twitter.com/) CLI.
 - [tv-remote-cli](https://github.com/Glavin001/tv-remote-cli) - CLI for remotely controlling your Smart TV.
 - [launch](https://github.com/NewSpring/meteor-launch) - Automating meteor builds to the AppStore, TestFlight, Hockey, Google Play, and more
+- [lifxsh](https://github.com/ristomatti/lifxsh) - Interactive shell for controlling [LIFX](http://www.lifx.com) smart lights.
 
 ## Extensions
 


### PR DESCRIPTION
I would like my project [lifxsh](https://github.com/ristomatti/lifxsh) to be added to the awesome-vorpal list now that I finally managed to write an actual README and publish the project to NPM. It's an Interactive shell for controlling [LIFX](http://www.lifx.com) smart lights.

I have used it myself for approximately a year and I believe there might be likeminded people who might find use for it.