### PR TITLE
Added "google-book-shell" link under "Projects"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [tv-remote-cli](https://github.com/Glavin001/tv-remote-cli) - CLI for remotely controlling your Smart TV.
 - [launch](https://github.com/NewSpring/meteor-launch) - Automating meteor builds to the AppStore, TestFlight, Hockey, Google Play, and more
 - [lifxsh](https://github.com/ristomatti/lifxsh) - Interactive shell for controlling [LIFX](http://www.lifx.com) smart lights.
+- [google-book-shell](https://github.com/dance2die/google-book-shell) - Search [Google Books](https://books.google.com/) from command line window.
 
 ## Extensions
 


### PR DESCRIPTION
Search Google Books from command line window.

The project page
https://github.com/dance2die/google-book-shell

The NPM page
https://www.npmjs.com/package/google-book-shell

> why it should be included

`Google-Book-Shell` makes searching books easy. It also demonstrates how easy it is to use Vorpal to create an CLI.